### PR TITLE
Envia a letra para os clientes com broadcast

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*

--- a/ClientUDP.java
+++ b/ClientUDP.java
@@ -1,0 +1,20 @@
+import java.net.*;
+
+class ClienteUDP {
+   private static int clientPort = 9871;
+   private static byte[] receiveData = new byte[1024];
+
+   public static void main(String args[]) throws Exception {
+      while (true) {
+         DatagramSocket clientSocket = new DatagramSocket(clientPort);
+         DatagramPacket receivePacket = new DatagramPacket(receiveData, receiveData.length);
+         clientSocket.receive(receivePacket);
+         clientSocket.close();
+
+         String received = new String(receivePacket.getData());
+         if (received.startsWith("startLetter=")) {
+            System.out.println("Letra: " + received.split("=")[1]);
+         }
+      }
+   }
+}

--- a/ServerUDP.java
+++ b/ServerUDP.java
@@ -1,0 +1,37 @@
+import java.net.*;
+import java.util.concurrent.ThreadLocalRandom;
+
+
+class ServerUDP {
+   private static int clientPort = 9871;
+   private static byte[] sendData = new byte[1024];
+   private static char[] alphabet = new char[] {
+      'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K',
+      'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V',
+      'W', 'X', 'Y', 'Z'
+   };
+
+   public static void main(String args[]) throws Exception {
+      DatagramSocket serverSocket = new DatagramSocket();
+
+      while(true) {
+         InetAddress ipBroadcast = InetAddress.getByName("192.168.15.255");
+
+         // TODO: ver se todos os clientes responderam que podem comecar antes de enviar a letra
+         sendLetter(serverSocket, ipBroadcast);
+      }
+   }
+
+   private static void sendLetter(DatagramSocket socket, InetAddress ipBroadcast) throws Exception {
+      int randomNum = ThreadLocalRandom.current().nextInt(0, alphabet.length);
+      char randLetter = alphabet[randomNum];
+
+      sendData = ("startLetter=" + randLetter).getBytes();
+
+      DatagramPacket sendPacket = new DatagramPacket(sendData, sendData.length, ipBroadcast, clientPort);
+      socket.send(sendPacket);
+      System.out.println("Enviado...");
+
+      Thread.sleep(500);
+   }
+}


### PR DESCRIPTION
¡Hola!

Aqui implementamos o envio de uma letra randômica para os clientes utilizando broadcast. Por padrão, os clientes estão rodando na porta 9871, e o servidor em uma aleatória. 

As classes de cliente e servidor UDP são também criadas para uso futuro.